### PR TITLE
Replace PseudoEnum through a real enum

### DIFF
--- a/Assets/NeoNetwork/Http/HttpMethod.cs
+++ b/Assets/NeoNetwork/Http/HttpMethod.cs
@@ -1,30 +1,9 @@
 namespace Neo.Network.Http {
   /// <summary>
-  /// Pseudo-Enum class for describing HTTP statis codes
+  /// Describes the possible HttpMethod that are currently supported
   /// </summary>
-  public sealed class HttpMethod {
-    /// <summary>
-    /// A GET request
-    /// </summary>
-    public static readonly HttpMethod GET  = new HttpMethod("GET");
-    /// <summary>
-    /// A POST request
-    /// </summary>
-    public static readonly HttpMethod POST = new HttpMethod("POST");
-    //more if needed
-
-    private readonly string name;
-
-    private HttpMethod(string name){
-      this.name = name;
-    }
-
-    /// <summary>
-    /// Return the name
-    /// </summary>
-    /// <returns>the name</returns>
-    public override string ToString(){
-      return name;
-    }
+  public enum HttpMethod {
+    POST,
+    GET
   }
 }


### PR DESCRIPTION
Why should we didn't use a real enum ? 
